### PR TITLE
ci(create-release): bump version before running build script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,13 +34,6 @@ jobs:
           token: ${{ steps.app_token.outputs.token }}
 
 
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Run build script
-        run: bun run build
-
-
       - name: Bump package version
         run: bun run .github/actions/bump-package-version.js
         env:
@@ -53,6 +46,13 @@ jobs:
           push: true
           default_author: github_actions
           message: 'chore: bump version to ${{ github.ref_name }}'
+
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run build script
+        run: bun run build
 
 
       - name: Bundle files


### PR DESCRIPTION
Fixes an issue where new releases still had old versions in their `fxmanifest.lua`/`package.json`.