### PR TITLE
Update AccountSettings.tsx

### DIFF
--- a/src/web/src/layouts/bank/pages/accounts/components/AccountSettings.tsx
+++ b/src/web/src/layouts/bank/pages/accounts/components/AccountSettings.tsx
@@ -63,7 +63,7 @@ const AccountSettings: React.FC = () => {
         <AccountButton
           label={locales.manage_access}
           icon={Shield}
-          disabled={account.type === 'personal' || !hasPermission('manageUser', account.role)}
+          disabled={account.type !== 'shared' || !hasPermission('manageUser', account.role)}
           onClick={() => navigate(`/accounts/manage-access/${account.id}`)}
         />
         <AccountButton


### PR DESCRIPTION
this PR disabled manage access button for both default groups & personal accounts. Default groups cannot be managed, 